### PR TITLE
feat: Add longer pauses for headings in TTS

### DIFF
--- a/scr/js/voice/textToSpeech.js
+++ b/scr/js/voice/textToSpeech.js
@@ -266,7 +266,7 @@ class TextToSpeechSystem {
         
         // Incluir el título del capítulo
         if (currentElement.tagName === 'H2') {
-            text += currentElement.textContent + '. ';
+            text += '@@PAUSE@@' + currentElement.textContent.trim() + '. ';
             currentElement = currentElement.nextElementSibling;
         }
 
@@ -282,8 +282,8 @@ class TextToSpeechSystem {
                 const tagName = currentElement.tagName.toLowerCase();
                 let elementText = currentElement.textContent.trim();
                 
-                if (tagName === 'h3' || tagName === 'h4') {
-                    text += elementText + '. ';
+                if (['h1', 'h3', 'h4', 'h5', 'h6'].includes(tagName)) {
+                    text += '@@PAUSE@@' + elementText + '. ';
                 } else if (tagName === 'p' || tagName === 'blockquote') {
                     text += elementText + ' ';
                 } else if (tagName === 'li') {
@@ -393,7 +393,13 @@ class TextToSpeechSystem {
             return;
         }
         
-        const sentence = this.sentences[this.currentSentenceIndex];
+        let sentence = this.sentences[this.currentSentenceIndex];
+        const isHeading = sentence.startsWith('@@PAUSE@@');
+
+        if (isHeading) {
+            sentence = sentence.replace('@@PAUSE@@', '').trim();
+        }
+
         this.utterance = new SpeechSynthesisUtterance(sentence);
         
         // Configurar voz
@@ -423,11 +429,12 @@ class TextToSpeechSystem {
         this.utterance.onend = () => {
             this.currentSentenceIndex++;
             // Pausa breve entre oraciones (más larga para mejor comprensión)
+            const pauseDuration = isHeading ? 1200 : 500;
             setTimeout(() => {
                 if (this.isPlaying) {
                     this.readNextSentence();
                 }
-            }, 500);
+            }, pauseDuration);
         };
         
         this.utterance.onerror = (event) => {


### PR DESCRIPTION
This commit enhances the text-to-speech (TTS) functionality by introducing longer pauses after reading heading elements (h1-h6).

To achieve this, the following changes were made:
- The `getChapterText` function now prepends a special marker (`@@PAUSE@@`) to heading elements when gathering text for synthesis.
- The `readNextSentence` function detects this marker, removes it before speech, and triggers a longer pause (1200ms vs. the standard 500ms) after the heading is read.

This creates a more natural and pleasant listening experience, allowing the user to better distinguish between headings and body text.